### PR TITLE
Make plugin vite compatible

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,20 +1,22 @@
 import glob from 'glob';
 import path from 'path';
-import { PluginHooks } from 'rollup';
+import type { Plugin } from 'rollup';
 
 // Watch any arbitrary project files for changes, such as static assets
 // (source:
 // <https://github.com/rollup/rollup/issues/3414#issuecomment-751699335>)
-function watchGlobs(globs: string[]): Partial<PluginHooks> {
+function watchGlobs(globs: string | readonly string[]): Plugin {
   return {
+    name: 'rollup-plugin-watch-globs',
     buildStart() {
-      for (const item of globs) {
-        glob.sync(path.resolve(item)).forEach((filename) => {
+      const items = Array.isArray(globs) ? globs : [globs];
+      items.forEach((item) => {
+        glob.sync(path.resolve(__dirname, item)).forEach((filename) => {
           this.addWatchFile(filename);
         });
-      }
-    }
-  }
+      });
+    },
+  };
 }
 
 export default watchGlobs;


### PR DESCRIPTION
Make this rollup plugin vite compatible by adding a name and using a Plugin type. Also allow single string parameter and not array. Also implemented suggestion from the original thread about `resolve` and `__dirname`